### PR TITLE
Add Ruby 4.0 to CI matrix and bump actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ jobs:
       matrix:
         ruby-version:
           - head
+          - '4.0'
           - '3.4'
           - '3.3'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Summary
- Add Ruby 4.0 to the CI test matrix (released Dec 2025)
- Bump `actions/checkout` from v4 to v6 in both CI and RuboCop workflows
- CI now tests: head, 4.0, 3.4, 3.3

## Test plan
- [x] `bundle exec rubocop --parallel` passes clean
- [x] `bundle exec rspec` passes all 1046 tests
- [ ] CI passes on all Ruby versions (head, 4.0, 3.4, 3.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)